### PR TITLE
Fix assigning attributes error

### DIFF
--- a/lib/value_objects/base.rb
+++ b/lib/value_objects/base.rb
@@ -16,7 +16,9 @@ module ValueObjects
     class << self
 
       def load(value)
-        new(value) if value
+        return nil if value.nil?
+        value = {} if value.blank? 
+        new(value)
       end
 
       def dump(value)


### PR DESCRIPTION
From Rails 5, when assigning attributes to Active Record object, you must pass a hash as an argument. Current codebase allows to create object with empty array. This is a fix to make the gem work.